### PR TITLE
Parse meta[name=go-import] tag for not-well-known sites

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -99,6 +99,10 @@ func parseImports(recursive bool) ([]string, error) {
 				continue
 			}
 
+			if inTests {
+				importpath = strings.Replace(importpath, "__blankd__", "localhost:60001", -1)
+			}
+
 			if isOwnPackage(importpath, cwd) {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -46,7 +49,24 @@ Options:
 
 var (
 	verbose bool
+	inTests bool
 )
+
+func init() {
+	for i, arg := range os.Args {
+		if arg == "--integration-test" {
+			inTests = true
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+		} else if arg == "--insecure-skip-verify" {
+			http.DefaultClient.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+		}
+	}
+}
 
 func main() {
 	args := godocs.MustParse(usage, version)

--- a/main.go
+++ b/main.go
@@ -53,19 +53,21 @@ var (
 )
 
 func init() {
-	for i, arg := range os.Args {
+	newArgs := make([]string, 0, len(os.Args))
+	for _, arg := range os.Args {
 		if arg == "--integration-test" {
 			inTests = true
-			os.Args = append(os.Args[:i], os.Args[i+1:]...)
 		} else if arg == "--insecure-skip-verify" {
 			http.DefaultClient.Transport = &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},
 			}
-			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+		} else {
+			newArgs = append(newArgs, arg)
 		}
 	}
+	os.Args = newArgs
 }
 
 func main() {

--- a/submodule.go
+++ b/submodule.go
@@ -12,6 +12,16 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
+// NOTE: This list is copied from
+// https://github.com/golang/go/blob/10538a8f9e2e718a47633ac5a6e90415a2c3f5f1/src/cmd/go/vcs.go#L821-L861
+var wellKnownSites = []string{
+	"github.com/",
+	"bitbucket.org/",
+	"hub.jazz.net/git/",
+	"git.apache.org/",
+	"git.openstack.org/",
+}
+
 func getVendorSubmodules() (map[string]string, error) {
 	output, err := execute(
 		exec.Command("git", "submodule", "status"),
@@ -78,16 +88,6 @@ func addVendorSubmodule(importpath string) error {
 	}
 
 	return errors.New(strings.Join(errs, "\n"))
-}
-
-// NOTE: This list is copied from
-// https://github.com/golang/go/blob/10538a8f9e2e718a47633ac5a6e90415a2c3f5f1/src/cmd/go/vcs.go#L821-L861
-var wellKnownSites = []string{
-	"github.com/",
-	"bitbucket.org/",
-	"hub.jazz.net/git/",
-	"git.apache.org/",
-	"git.openstack.org/",
 }
 
 func getHttpsURLForImportPath(importpath string) (url string, err error) {

--- a/submodule.go
+++ b/submodule.go
@@ -94,7 +94,7 @@ func getHttpsURLForImportPath(importpath string) (url string, err error) {
 	url = "https://" + importpath
 	for _, site := range wellKnownSites {
 		if strings.HasPrefix(importpath, site) {
-			return
+			return url, nil
 		}
 	}
 
@@ -126,7 +126,10 @@ func getHttpsURLForImportPath(importpath string) (url string, err error) {
 			url = repoRoot
 		}
 	})
-	return
+	if err != nil {
+		return "", err
+	}
+	return url, nil
 }
 
 func removeVendorSubmodule(importpath string) error {

--- a/submodule.go
+++ b/submodule.go
@@ -90,6 +90,8 @@ func addVendorSubmodule(importpath string) error {
 	return errors.New(strings.Join(errs, "\n"))
 }
 
+const tag = "meta[name=go-import]"
+
 func getHttpsURLForImportPath(importpath string) (url string, err error) {
 	url = "https://" + importpath
 	for _, site := range wellKnownSites {
@@ -105,18 +107,21 @@ func getHttpsURLForImportPath(importpath string) (url string, err error) {
 	if err != nil {
 		return
 	}
-	doc.Find("meta[name=go-import]").Each(func(_ int, selection *goquery.Selection) {
+	doc.Find(tag).Each(func(_ int, selection *goquery.Selection) {
 		if err != nil {
 			return
 		}
 		content, exists := selection.Attr("content")
 		if !exists {
-			err = fmt.Errorf(`"content" attribute not found in meta name="go-import" at %s`, url)
+			err = fmt.Errorf(`"content" attribute not found in `+
+				`meta name="go-import" at %s`, url)
 			return
 		}
 		terms := strings.Fields(content)
 		if len(terms) != 3 {
-			err = fmt.Errorf(`invalid formatted "content" attribute in meta name="go-import" at %s`, url)
+			err = fmt.Errorf(
+				`invalid formatted "content" attribute in `+
+					`meta name="go-import" at %s`, url)
 			return
 		}
 		prefix := terms[0]

--- a/submodule.go
+++ b/submodule.go
@@ -105,11 +105,11 @@ func getHttpsURLForImportPath(importpath string) (url string, err error) {
 	if err != nil {
 		return
 	}
-	doc.Find("meta[name=go-import]").Each(func(i int, s *goquery.Selection) {
+	doc.Find("meta[name=go-import]").Each(func(_ int, selection *goquery.Selection) {
 		if err != nil {
 			return
 		}
-		content, exists := s.Attr("content")
+		content, exists := selection.Attr("content")
 		if !exists {
 			err = fmt.Errorf(`"content" attribute not found in meta name="go-import" at %s`, url)
 			return

--- a/tests/-Q-parse-meta-go-import.test.sh
+++ b/tests/-Q-parse-meta-go-import.test.sh
@@ -1,0 +1,18 @@
+:project "main.go" <<GO
+package main
+
+import foo "manul-test-foo.appspot.com/a/b"
+
+func main() {
+    foo.Foo()
+}
+GO
+
+# NOTE: See https://github.com/hnakamur/google-app-engine-manul-test-foo
+# for source code of application manul-test-foo
+:lib "manul-test-foo.appspot.com/a/b"
+
+tests:ensure :manul -Q
+tests:assert-no-diff stdout <<VENDORS
+manul-test-foo.appspot.com/a/b
+VENDORS

--- a/tests/-Q-parse-meta-go-import.test.sh
+++ b/tests/-Q-parse-meta-go-import.test.sh
@@ -22,12 +22,13 @@ SRV
 tests:ensure chmod +x $(tests:get-tmp-dir)/server
 
 
+:lib "github.com/kovetskiy/blankd"
 :lib "github.com/kovetskiy/manul-test-foo"
 tests:ensure  mv \
     $(tests:get-tmp-dir)/go/src/github.com \
     $(tests:get-tmp-dir)/go/src/__blankd__
 
-tests:ensure blankd \
+tests:ensure $(tests:get-tmp-dir)/go/bin/blankd \
     -l localhost:60001 \
     -e $(tests:get-tmp-dir)/server \
     -o $(tests:get-tmp-dir)/blankd.log \


### PR DESCRIPTION
This pull request adds support for dynamic sites like "google.golang.org/grpc"
