### PR TITLE
Refactor dependency calculations

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -43,13 +42,15 @@ func parseImports(recursive bool, testDependencies bool) ([]string, error) {
 	return imports, nil
 }
 
-func calculateDependencies(packages []string, recursive, testDependencies bool) ([]string, error) {
+func calculateDependencies(packages []string, recursive,
+	testDependencies bool) ([]string, error) {
 	var deps, imports, testImports, testDeps []string
 
 	for _, pkg := range packages {
 		data, err := list(pkg)
 		if err != nil {
-			return imports, fmt.Errorf("failed to list dependencies for %s: %s", pkg, err)
+			return imports,
+				fmt.Errorf("failed to list dependencies for %s: %s", pkg, err)
 		}
 
 		if recursive {
@@ -68,7 +69,9 @@ func calculateDependencies(packages []string, recursive, testDependencies bool) 
 		for _, testImport := range testImports {
 			testData, err := list(testImport)
 			if err != nil {
-				return imports, fmt.Errorf("failed to list dependencies for testing package %s: %s", testImport, err)
+				return imports, fmt.Errorf(
+					"failed to list dependencies for testing package %s: %s",
+					testImport, err)
 			}
 			testDeps = append(testDeps, testData.Deps...)
 		}
@@ -92,7 +95,8 @@ func filterPackages(packages []string) []string {
 		}
 
 		if inTests {
-			importpath = strings.Replace(importpath, "__blankd__", "localhost:60001", -1)
+			importpath = strings.Replace(importpath,
+				"__blankd__", "localhost:60001", -1)
 		}
 
 		if isOwnPackage(importpath) {
@@ -122,16 +126,16 @@ func filterPackages(packages []string) []string {
 	return imports
 }
 
-func ensureDependenciesExist(packages []string, includeTestingDependencies bool) error {
+func ensureDependenciesExist(packages []string, includeTestDeps bool) error {
 	args := []string{"get"}
-	if includeTestingDependencies {
+	if includeTestDeps {
 		args = append(args, "-t")
 	}
 	args = append(args, packages...)
 
 	out, err := execute(exec.Command("go", args...))
 	if err != nil {
-		return fmt.Errorf("couldn't 'go get' dependencies:\n%s", out)
+		return fmt.Errorf("can't 'go get' dependencies:\n%s", out)
 	}
 
 	return nil
@@ -147,7 +151,8 @@ func list(pkg string) (listOutput, error) {
 
 	err = json.Unmarshal([]byte(out), &data)
 	if err != nil {
-		return data, fmt.Errorf("can't unmarshal go list JSON output: %s\n%q", err, out)
+		return data,
+			fmt.Errorf("can't unmarshal go list JSON output: %s\n%q", err, out)
 	}
 
 	return data, nil
@@ -161,10 +166,7 @@ func listPackages() ([]string, error) {
 		return packages, err
 	}
 
-	r := strings.NewReader(out)
-	s := bufio.NewScanner(r)
-	for s.Scan() {
-		pkg := s.Text()
+	for _, pkg := range strings.Split(strings.TrimSpace(out), "\n") {
 		if strings.Contains(pkg, "/vendor/") {
 			continue
 		}

--- a/imports.go
+++ b/imports.go
@@ -25,10 +25,10 @@ func parseImports(recursive bool, testDependencies bool) ([]string, error) {
 	}
 
 	// Ensuring our dependencies exists isn't a strict requirement, therefore
-	// only print a message to stderr rather then completely failing
+	// only print a message to stderr rather then completely failing.
 	err = ensureDependenciesExist(packages, testDependencies)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 	}
 
 	imports, err = calculateDependencies(packages, recursive, testDependencies)
@@ -84,7 +84,6 @@ func calculateDependencies(packages []string, recursive, testDependencies bool) 
 
 func filterPackages(packages []string) []string {
 	var imports []string
-	cwd, _ := os.Getwd()
 
 	for _, importing := range packages {
 		importpath, err := getRootImportpath(importing)
@@ -96,7 +95,7 @@ func filterPackages(packages []string) []string {
 			importpath = strings.Replace(importpath, "__blankd__", "localhost:60001", -1)
 		}
 
-		if isOwnPackage(importpath, cwd) {
+		if isOwnPackage(importpath) {
 			continue
 		}
 
@@ -132,7 +131,7 @@ func ensureDependenciesExist(packages []string, includeTestingDependencies bool)
 
 	out, err := execute(exec.Command("go", args...))
 	if err != nil {
-		return fmt.Errorf("couldn't go get dependencies:\n %s", out)
+		return fmt.Errorf("couldn't 'go get' dependencies:\n%s", out)
 	}
 
 	return nil
@@ -176,9 +175,9 @@ func listPackages() ([]string, error) {
 	return packages, nil
 }
 
-func isOwnPackage(path, cwd string) bool {
+func isOwnPackage(path string) bool {
 	for _, gopath := range filepath.SplitList(os.Getenv("GOPATH")) {
-		if strings.HasPrefix(filepath.Join(gopath, "src", path), cwd) {
+		if strings.HasPrefix(filepath.Join(gopath, "src", path), workdir) {
 			return true
 		}
 	}

--- a/imports.go
+++ b/imports.go
@@ -15,7 +15,7 @@ func parseImports(recursive bool, testDependencies bool) ([]string, error) {
 	var imports []string
 	packages, err := listPackages()
 	if err != nil {
-		return imports, nil
+		return imports, fmt.Errorf("error listing packages: %s", err)
 	}
 
 	ensureDependenciesExist(packages, testDependencies)
@@ -145,7 +145,7 @@ func list(pkg string) (listOutput, error) {
 func listPackages() ([]string, error) {
 	var packages []string
 
-	out, err := execute(exec.Command("go", "list", "./..."))
+	out, err := execute(exec.Command("go", "list", "-e", "./..."))
 	if err != nil {
 		return packages, err
 	}

--- a/main.go
+++ b/main.go
@@ -73,7 +73,8 @@ func init() {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't get current working directory: %s\n", err)
+		fmt.Fprintf(os.Stderr,
+			"can't get current working directory: %s\n", err)
 		os.Exit(1)
 	}
 	workdir = cwd
@@ -91,8 +92,8 @@ func main() {
 
 		dependencies, _ = args["<dependency>"].([]string)
 
-		recursive        = args["--recursive"].(bool)
-		testDependencies = args["--testing"].(bool)
+		recursive       = args["--recursive"].(bool)
+		includeTestDeps = args["--testing"].(bool)
 	)
 
 	verbose = args["--verbose"].(bool)
@@ -100,20 +101,20 @@ func main() {
 	var err error
 	switch {
 	case modeInstall:
-		err = handleInstall(recursive, testDependencies, dependencies)
+		err = handleInstall(recursive, includeTestDeps, dependencies)
 
 	case modeUpdate:
-		err = handleUpdate(recursive, testDependencies, dependencies)
+		err = handleUpdate(recursive, includeTestDeps, dependencies)
 
 	case modeQuery:
 		onlyVendored := args["-o"].(bool)
-		err = handleQuery(recursive, testDependencies, onlyVendored)
+		err = handleQuery(recursive, includeTestDeps, onlyVendored)
 
 	case modeRemove:
 		err = handleRemove(dependencies)
 
 	case modeClean:
-		err = handleClean(recursive, testDependencies)
+		err = handleClean(recursive, includeTestDeps)
 	}
 
 	if err != nil {
@@ -121,8 +122,9 @@ func main() {
 	}
 }
 
-func handleInstall(recursive bool, testDependencies bool, dependencies []string) error {
-	imports, err := parseImports(recursive, testDependencies)
+func handleInstall(recursive bool, includeTestDeps bool,
+	dependencies []string) error {
+	imports, err := parseImports(recursive, includeTestDeps)
 	if err != nil {
 		return err
 	}
@@ -190,10 +192,11 @@ func handleInstall(recursive bool, testDependencies bool, dependencies []string)
 	return nil
 }
 
-func handleUpdate(recursive bool, testDependencies bool, dependencies []string) error {
+func handleUpdate(recursive bool, includeTestDeps bool,
+	dependencies []string) error {
 	var err error
 	if len(dependencies) == 0 {
-		dependencies, err = parseImports(recursive, testDependencies)
+		dependencies, err = parseImports(recursive, includeTestDeps)
 		if err != nil {
 			return err
 		}
@@ -261,7 +264,7 @@ func handleRemove(dependencies []string) error {
 	return nil
 }
 
-func handleQuery(recursive, testDependencies, onlyVendored bool) error {
+func handleQuery(recursive, includeTestDeps, onlyVendored bool) error {
 	submodules, err := getVendorSubmodules()
 	if err != nil {
 		return err
@@ -275,7 +278,7 @@ func handleQuery(recursive, testDependencies, onlyVendored bool) error {
 			fmt.Printf(format, submodule, commit)
 		}
 	} else {
-		imports, err := parseImports(recursive, testDependencies)
+		imports, err := parseImports(recursive, includeTestDeps)
 		if err != nil {
 			return err
 		}
@@ -303,8 +306,8 @@ func handleQuery(recursive, testDependencies, onlyVendored bool) error {
 	return nil
 }
 
-func handleClean(recursive, testDependencies bool) error {
-	imports, err := parseImports(recursive, testDependencies)
+func handleClean(recursive, includeTestDeps bool) error {
+	imports, err := parseImports(recursive, includeTestDeps)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ Options:
 var (
 	verbose bool
 	inTests bool
+	workdir string
 )
 
 func init() {
@@ -69,6 +70,12 @@ func init() {
 		}
 	}
 	os.Args = newArgs
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Errorf("couldn't get current working directory: %s", err))
+	}
+	workdir = cwd
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ Options:
     -Q --query      List all dependencies.
         -o          List only already-vendored dependencies.
     -C --clean      Detect all unused vendored dependencies and remove it.
-	-t --testing    Include testing dependencies.
+    -t --testing    Include testing dependencies.
     -r --recursive  Be recursive.
     -h --help       Show help message.
     -v --verbose    Be verbose.

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ Options:
     -Q --query      List all dependencies.
         -o          List only already-vendored dependencies.
     -C --clean      Detect all unused vendored dependencies and remove it.
-    -t --testing    Include testing dependencies.
+    -t --testing    Include dependencies from tests.
     -r --recursive  Be recursive.
     -h --help       Show help message.
     -v --verbose    Be verbose.

--- a/main.go
+++ b/main.go
@@ -73,7 +73,8 @@ func init() {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic(fmt.Errorf("couldn't get current working directory: %s", err))
+		fmt.Fprintf(os.Stderr, "couldn't get current working directory: %s\n", err)
+		os.Exit(1)
 	}
 	workdir = cwd
 }

--- a/submodule.go
+++ b/submodule.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"go/build"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -171,15 +170,10 @@ func removeVendorSubmodule(importpath string) error {
 }
 
 func updateVendorSubmodule(importpath string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	cmd := exec.Command("git", "pull", "origin", "master")
-	cmd.Dir = filepath.Join(cwd, "vendor", importpath)
+	cmd.Dir = filepath.Join(workdir, "vendor", importpath)
 
-	_, err = execute(cmd)
+	_, err := execute(cmd)
 
 	return err
 }
@@ -190,8 +184,7 @@ func getRootImportpath(importpath string) (string, error) {
 		return "", err
 	}
 
-	cwd, _ := os.Getwd()
-	vendorPath := strings.TrimPrefix(cwd, pkg.SrcRoot+"/") + "/vendor/"
+	vendorPath := strings.TrimPrefix(workdir, pkg.SrcRoot+"/") + "/vendor/"
 
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = filepath.Join(pkg.SrcRoot, importpath)

--- a/submodule.go
+++ b/submodule.go
@@ -190,6 +190,9 @@ func getRootImportpath(importpath string) (string, error) {
 		return "", err
 	}
 
+	cwd, _ := os.Getwd()
+	vendorPath := strings.TrimPrefix(cwd, pkg.SrcRoot+"/") + "/vendor/"
+
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = filepath.Join(pkg.SrcRoot, importpath)
 
@@ -198,8 +201,7 @@ func getRootImportpath(importpath string) (string, error) {
 		return "", err
 	}
 
-	return strings.Trim(
+	return strings.TrimPrefix(strings.Trim(
 		strings.TrimSpace(strings.TrimPrefix(rootdir, pkg.SrcRoot)),
-		"/",
-	), nil
+		"/"), vendorPath), nil
 }

--- a/utils.go
+++ b/utils.go
@@ -16,8 +16,8 @@ func execute(cmd *exec.Cmd) (string, error) {
 		}
 	}
 
-	stdout, _, err := executil.Run(cmd)
-	return string(stdout), err
+	stdout, stderr, err := executil.Run(cmd)
+	return string(stdout) + string(stderr), err
 }
 
 func getMaxLength(elements []string) int {


### PR DESCRIPTION
- Now honors recursive flag (fixes kovetskiy/manul#30)
- Option to include testing dependencies (fixes kovetskiy/manul#15)
- Don't include recursive deps if they are already vendored (fixes kovetskiy/manul#3
- Don't vendor unused packages (fixes kovetskiy/manul#30)
- Do a got get at the beginning as a usability feature (fixes kovetskiy/manul#26)
- Should also fix kovetskiy/manul#27, though unconfirmed