### PR TITLE
Added the local GOPATH folder as primary dependencies's source

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -21,6 +21,7 @@ var wellKnownSites = []string{
 	"hub.jazz.net/git/",
 	"git.apache.org/",
 	"git.openstack.org/",
+	"beanstalkapp.com/"
 }
 
 func getVendorSubmodules() (map[string]string, error) {
@@ -58,7 +59,9 @@ func getVendorSubmodules() (map[string]string, error) {
 func addVendorSubmodule(importpath string) []error {
 	var (
 		target   = "vendor/" + importpath
+		gopath = os.Getenv("GOPATH")
 		prefixes = []string{
+			fmt.Sprintf("file://%s/src/",gopath), // Tries to take the dependency from the local GOPATH
 			"https://",
 			"git+ssh://",
 			"git://",

--- a/submodule.go
+++ b/submodule.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	ser "github.com/reconquest/ser-go"
 )
 
 const tagMetaGoImport = "meta[name=go-import]"
@@ -29,9 +30,7 @@ func getVendorSubmodules() (map[string]string, error) {
 		exec.Command("git", "submodule", "status"),
 	)
 	if err != nil {
-		return nil, ser.Errorf(
-			err, "unable to get submodules status",
-		)
+		return nil, err
 	}
 
 	vendors := map[string]string{}
@@ -58,16 +57,17 @@ func getVendorSubmodules() (map[string]string, error) {
 
 func addVendorSubmodule(importpath string) []error {
 	var (
-		target   = "vendor/" + importpath
-		gopath   = os.Getenv("GOPATH")
+		target  = "vendor/" + importpath
+		gopath  = os.Getenv("GOPATH")
+		fileUrl = fmt.Sprintf("file://%s/src/", gopath)
+
 		prefixes = []string{
-			fmt.Sprintf("file://%s/src/", gopath), // Tries to take the dependency from the local GOPATH
+			fileUrl, // Tries to take the dependency from the local GOPATH
 			"https://",
 			"git+ssh://",
 			"git://",
 		}
-
-		errs []error
+		errs = make([]error, 0)
 	)
 
 	for _, prefix := range prefixes {

--- a/submodule.go
+++ b/submodule.go
@@ -3,12 +3,12 @@ package main
 import (
 	"fmt"
 	"go/build"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/reconquest/ser-go"
 )
 
 const tagMetaGoImport = "meta[name=go-import]"
@@ -21,7 +21,7 @@ var wellKnownSites = []string{
 	"hub.jazz.net/git/",
 	"git.apache.org/",
 	"git.openstack.org/",
-	"beanstalkapp.com/"
+	"beanstalkapp.com/",
 }
 
 func getVendorSubmodules() (map[string]string, error) {
@@ -59,9 +59,9 @@ func getVendorSubmodules() (map[string]string, error) {
 func addVendorSubmodule(importpath string) []error {
 	var (
 		target   = "vendor/" + importpath
-		gopath = os.Getenv("GOPATH")
+		gopath   = os.Getenv("GOPATH")
 		prefixes = []string{
-			fmt.Sprintf("file://%s/src/",gopath), // Tries to take the dependency from the local GOPATH
+			fmt.Sprintf("file://%s/src/", gopath), // Tries to take the dependency from the local GOPATH
 			"https://",
 			"git+ssh://",
 			"git://",


### PR DESCRIPTION
Hi, 
   I have had problems to use Manul with **beanstalkapp.com**. So, I have decided to download my beanstalkapp dependencies with `go get` tool, and modify the _submodule.go_ source so that it first try to import the dependencies from the local GOPATH.

Regards,
Jaume Arús