### PR TITLE
Fix "unable to go get dependencies"

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -145,6 +145,11 @@ func filterPackages(packages []string) []string {
 }
 
 func ensureDependenciesExist(packages []string, includeTestDeps bool) error {
+	packages = filterPackages(packages)
+	if len(packages) <= 0 {
+		return nil
+	}
+
 	args := []string{"get", "-d"} // -d for download only
 
 	if includeTestDeps {


### PR DESCRIPTION
First of all, thank you for this lib, it's awesome :)

-----

Let say I have `GOPATH="~/go/src"`
And I'm working in `~/go/src/my_repo`
`manul -Q` (or `-I`...) will complain with: `[ERROR]: unable to go get dependencies: my_repo/...`
Because it is trying to do `go get -d my_repo/...` (in `ensureDependenciesExist`) which obviously is not what we want.
So I used the `filterPackages` function that exclude our own packages.

Let me know what you think.
By the way, it would be nice to have some instructions in the README.md on how to run the tests. I can't figure it out.