### PR TITLE
travis: skip builds for pkg-* branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  except:
+  - /^pkg-/
+
 language: go
 go:
  - 1.7


### PR DESCRIPTION
This skips building for package branches (any branch starting with `pkg-`) and should fix build failures when opening pull requests against pkg-archlinux (#41) and pkg-debian (#42).