### PR TITLE
travis: go install blankd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
  - 1.7
 
 script:
+- go get -u -v github.com/kovetskiy/blankd
 - git submodule update --init --recursive
 - go get
 - make test


### PR DESCRIPTION
This should fix [recent build failures](https://travis-ci.org/kovetskiy/manul/builds/307647118) caused by the missing test suite dependency.