### PR TITLE
Call 'go get' and 'go list' with lists of packages rather than for each package.

### DIFF
--- a/handle_tree.go
+++ b/handle_tree.go
@@ -102,19 +102,19 @@ func getTree(
 	}
 
 	list, err := golist(pkg)
-	if err != nil {
+	if err != nil || len(list) != 1 {
 		logger.Fatal(err)
 	}
 
 	var imports []string
-	var listing []string
+	var importList []string
 	if usePath {
-		listing = list.Deps
+		importList = list[0].Deps
 	} else {
-		listing = list.Imports
+		importList = list[0].Imports
 	}
 
-	for _, importing := range listing {
+	for _, importing := range importList {
 		imports = append(imports, removeVendorPrefix(importing))
 	}
 
@@ -134,7 +134,7 @@ func getTree(
 	}
 
 	if withTests {
-		testImports := filterPackages(list.TestImports, 0)
+		testImports := filterPackages(list[0].TestImports, 0)
 		for _, imported := range testImports {
 			tree.Nested = append(
 				tree.Nested,

--- a/handle_tree.go
+++ b/handle_tree.go
@@ -102,7 +102,7 @@ func getTree(
 	}
 
 	list, err := golist(pkg)
-	if err != nil || len(list) != 1 {
+	if err != nil {
 		logger.Fatal(err)
 	}
 

--- a/imports.go
+++ b/imports.go
@@ -57,7 +57,7 @@ func calculateDependencies(
 	data, err := golist(packages...)
 	if err != nil {
 		return nil, karma.Format(
-			err, "unable to list dependecies for some packages in: %v", packages,
+			err, "unable to list dependencies for some packages in: %v", packages,
 		)
 	}
 
@@ -80,7 +80,7 @@ func calculateDependencies(
 		testData, err := golist(testImports...)
 		if err != nil {
 			return nil, karma.Format(
-				err, "unable to list dependecies for some test packages in: %v", testImports)
+				err, "unable to list dependencies for some test packages in: %v", testImports)
 		}
 
 		for _, pkgMetaData := range testData {

--- a/imports.go
+++ b/imports.go
@@ -33,13 +33,11 @@ func parseImports(recursive bool, testDependencies bool) ([]string, error) {
 	// only print a message to stderr rather then completely failing.
 
 	err = ensureDependenciesExist(packages, true)
-
 	if err != nil {
 		logger.Warning(err)
 	}
 
 	imports, err = calculateDependencies(packages, recursive, testDependencies)
-
 	if err != nil {
 		return imports, err
 	}
@@ -57,7 +55,6 @@ func calculateDependencies(
 	var deps, testImports, testDeps []string
 
 	data, err := golist(packages...)
-
 	if err != nil {
 		return nil, karma.Format(
 			err, "unable to list dependecies for some packages in: %v", packages,
@@ -81,7 +78,6 @@ func calculateDependencies(
 
 	if recursive {
 		testData, err := golist(testImports...)
-
 		if err != nil {
 			return nil, karma.Format(
 				err, "unable to list dependecies for some test packages in: %v", testImports)
@@ -157,7 +153,6 @@ func filterPackages(packages []string, mode build.ImportMode) []string {
 }
 
 func ensureDependenciesExist(packages []string, withTests bool) error {
-
 	if packages == nil {
 		return errors.New("packages list cannot be empty")
 	}
@@ -173,7 +168,6 @@ func ensureDependenciesExist(packages []string, withTests bool) error {
 	}
 
 	_, err := execute(exec.Command("go", args...))
-
 	if err != nil {
 		return karma.Format(
 			err,
@@ -199,7 +193,6 @@ func golist(packages ...string) ([]golistOutput, error) {
 	}
 
 	jsonStream, err := execute(exec.Command("go", args...))
-
 	if err != nil {
 		return result, err
 	}
@@ -208,8 +201,8 @@ func golist(packages ...string) ([]golistOutput, error) {
 
 	for {
 		pkgMetaData := golistOutput{}
-		err := decoder.Decode(&pkgMetaData)
 
+		err := decoder.Decode(&pkgMetaData)
 		if err != nil {
 			return result, karma.Format(err, "failed to decode go list output")
 		}

--- a/imports.go
+++ b/imports.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"go/build"
 	"os"
 	"os/exec"
@@ -30,22 +31,21 @@ func parseImports(recursive bool, testDependencies bool) ([]string, error) {
 
 	// Ensuring our dependencies exists isn't a strict requirement, therefore
 	// only print a message to stderr rather then completely failing.
-	for _, pkg := range packages {
-		err = ensureDependenciesExist(pkg, testDependencies)
-		if err != nil {
-			logger.Warning(err)
-		}
+
+	err = ensureDependenciesExist(packages, true)
+
+	if err != nil {
+		logger.Warning(err)
 	}
 
 	imports, err = calculateDependencies(packages, recursive, testDependencies)
+
 	if err != nil {
 		return imports, err
 	}
 
 	imports = filterPackages(imports, build.IgnoreVendor)
-
 	sort.Strings(imports)
-
 	return imports, nil
 }
 
@@ -54,40 +54,41 @@ func calculateDependencies(
 	recursive,
 	testDependencies bool,
 ) ([]string, error) {
-	var deps, imports, testImports, testDeps []string
+	var deps, testImports, testDeps []string
 
-	for _, pkg := range packages {
-		data, err := golist(pkg)
-		if err != nil {
-			return imports, karma.Format(
-				err, "unable to list dependecies for package: %s", pkg,
-			)
-		}
+	data, err := golist(packages...)
 
+	if err != nil {
+		return nil, karma.Format(
+			err, "unable to list dependecies for some packages in: %v", packages,
+		)
+	}
+
+	for _, pkgMetaData := range data {
 		if recursive {
-			deps = append(deps, data.Deps...)
+			deps = append(deps, pkgMetaData.Deps...)
 		} else {
-			deps = append(deps, data.Imports...)
+			deps = append(deps, pkgMetaData.Imports...)
 		}
 
 		if testDependencies {
-			testImports = append(testImports, data.TestImports...)
-			testImports = append(testImports, data.XTestImports...)
+			testImports = append(testImports, pkgMetaData.TestImports...)
+			testImports = append(testImports, pkgMetaData.XTestImports...)
 		}
 	}
 
 	testImports = unique(testImports)
-	if recursive {
-		for _, testImport := range testImports {
-			testData, err := golist(testImport)
-			if err != nil {
-				return imports, karma.Format(
-					err, "unable to list dependencies for package: %s",
-					testImport,
-				)
-			}
 
-			testDeps = append(testDeps, testData.Deps...)
+	if recursive {
+		testData, err := golist(testImports...)
+
+		if err != nil {
+			return nil, karma.Format(
+				err, "unable to list dependecies for some test packages in: %v", testImports)
+		}
+
+		for _, pkgMetaData := range testData {
+			testDeps = append(testDeps, pkgMetaData.Deps...)
 		}
 
 		deps = append(deps, testDeps...)
@@ -155,41 +156,72 @@ func filterPackages(packages []string, mode build.ImportMode) []string {
 	return imports
 }
 
-func ensureDependenciesExist(pkg string, withTests bool) error {
+func ensureDependenciesExist(packages []string, withTests bool) error {
+
+	if packages == nil {
+		return errors.New("packages list cannot be empty")
+	}
+
 	args := []string{"get", "-d"} // -d for download only
 
 	if withTests {
 		args = append(args, "-t")
 	}
 
-	args = append(args, pkg)
+	for _, pkg := range packages {
+		args = append(args, pkg)
+	}
 
 	_, err := execute(exec.Command("go", args...))
+
 	if err != nil {
 		return karma.Format(
 			err,
-			"unable to go get dependencies for %s",
-			pkg,
+			"unable to go get dependencies for one of the packages in %v",
+			packages,
 		)
 	}
 
 	return nil
 }
 
-func golist(pkg string) (golistOutput, error) {
-	data := golistOutput{}
+func golist(packages ...string) ([]golistOutput, error) {
+	result := []golistOutput{}
 
-	out, err := execute(exec.Command("go", "list", "-e", "-json", pkg))
-	if err != nil {
-		return data, err
+	if packages == nil {
+		return result, errors.New("packages list cannot be empty")
 	}
 
-	err = json.Unmarshal([]byte(out), &data)
-	if err != nil {
-		return data, karma.Format(err, "unable to decode `go list` JSON output")
+	args := []string{"list", "-e", "-json"}
+
+	for _, pkg := range packages {
+		args = append(args, pkg)
 	}
 
-	return data, nil
+	jsonStream, err := execute(exec.Command("go", args...))
+
+	if err != nil {
+		return result, err
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(jsonStream))
+
+	for {
+		pkgMetaData := golistOutput{}
+		err := decoder.Decode(&pkgMetaData)
+
+		if err != nil {
+			return result, karma.Format(err, "failed to decode go list output")
+		}
+
+		result = append(result, pkgMetaData)
+
+		if !decoder.More() {
+			break
+		}
+	}
+
+	return result, nil
 }
 
 func listPackages() ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ Options:
         -o          List only already-vendored dependencies.
     -C --clean      Detect all unused vendored dependencies and remove it.
     -T --tree       Show dependencies tree.
-	  -i --import   Show used import path instead of git repo.
+    -i --import     Show used import path instead of git repo.
     -t --testing    Include dependencies from tests.
     -r --recursive  Be recursive.
     -h --help       Show help message.

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ Options:
         -o          List only already-vendored dependencies.
     -C --clean      Detect all unused vendored dependencies and remove it.
     -T --tree       Show dependencies tree.
-    -i --import     Show used import path instead of git repo.
+	  -i --import   Show used import path instead of git repo.
     -t --testing    Include dependencies from tests.
     -r --recursive  Be recursive.
     -h --help       Show help message.


### PR DESCRIPTION
Concatenating requests significantly reduces networking overhead.
In my test case, ./manul -Q went down from 2 minutes to 5 seconds.